### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ six==1.16.0
 
 # typing extensions (must be installed at runtime because of Django stubs)
 django-stubs==5.1.3
-django-stubs-ext==5.1.2
+django-stubs-ext==5.1.3
 types-cryptography==3.3.23.2
 types-oauthlib==3.2.0.20240806
 types-requests==2.32.0.20241016


### PR DESCRIPTION
django-stubs 5.1.3 depends on django-stubs-ext 5.1.3. Fixing dependencies.