### PR TITLE
Fix oauth2 list client search crashing

### DIFF
--- a/authserver/mailauth/management/commands/oauth2.py
+++ b/authserver/mailauth/management/commands/oauth2.py
@@ -121,16 +121,16 @@ class Command(BaseCommand):
     def _list(self, **kwargs: Any) -> None:
         clients = []  # type: List[oauth2_models.Application]
         if kwargs["search_client_id"]:
-            try:
-                clients = list(appmodel.objects.filter(client_id__ilike=kwargs["search_client_id"]))
-            except appmodel.DoesNotExist:
+            clients = list(appmodel.objects.filter(client_id__icontains=kwargs["search_client_id"]))
+            if not clients:
                 self.stderr.write(self.style.ERROR("Client ID not found %s" % kwargs["search_client_id"]))
+                return
 
         elif kwargs["search_client_name"]:
-            try:
-                clients = list(appmodel.objects.file(name__ilike=kwargs["search_client_name"]))
-            except appmodel.DoesNotExist:
+            clients = list(appmodel.objects.filter(name__icontains=kwargs["search_client_name"]))
+            if not clients:
                 self.stderr.write(self.style.ERROR("Client name not found %s" % kwargs["search_client_name"]))
+                return
 
         else:
             clients = list(appmodel.objects.all())

--- a/authserver/mailauth/tests/test_management_commands.py
+++ b/authserver/mailauth/tests/test_management_commands.py
@@ -181,3 +181,40 @@ class PermissionsCommandTests(TestCase):
         payload = json.loads(out.getvalue())
         self.assertEqual(1, len(payload))
         self.assertEqual(self.permission.permission_name, payload[0]["permission_name"])
+
+
+class OAuth2CommandTests(TestCase):
+    def setUp(self) -> None:
+        self.app = models.MNApplication.objects.create(
+            name="testclient",
+            client_type=models.MNApplication.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=models.MNApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="https://client.example.com/callback",
+        )
+
+    def test_list_all(self) -> None:
+        out = StringIO()
+        with redirect_stdout(out):
+            call_command("oauth2", "list")
+        self.assertIn("testclient", out.getvalue())
+        self.assertIn(self.app.client_id, out.getvalue())
+
+    def test_list_search_by_client_name(self) -> None:
+        out = StringIO()
+        with redirect_stdout(out):
+            call_command("oauth2", "list", "--search-client-name", "testclient")
+        self.assertIn(self.app.client_id, out.getvalue())
+
+    def test_list_search_by_client_id(self) -> None:
+        out = StringIO()
+        with redirect_stdout(out):
+            call_command("oauth2", "list", "--search-client-id", self.app.client_id)
+        self.assertIn("testclient", out.getvalue())
+
+    def test_list_search_by_client_name_not_found(self) -> None:
+        out = StringIO()
+        err = StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            call_command("oauth2", "list", "--search-client-name", "does-not-exist")
+        self.assertNotIn(self.app.client_id, out.getvalue())
+        self.assertIn("Client name not found", err.getvalue())


### PR DESCRIPTION
'oauth2 list --search-client-name' crashed with an AttributeError (objects.file instead of objects.filter) and both search branches used the invalid '__ilike' lookup, which raises FieldError for --search-client-id. Use filter() with '__icontains' (the Django equivalent of SQL ILIKE substring matching) and report a not-found search on stderr instead of relying on the dead DoesNotExist handler (filter() never raises it).

Adds regression tests for oauth2 list and both search options.


Claude-Session: https://claude.ai/code/session_01AgWqnQ8ExYjdZofXbvJZEz